### PR TITLE
feat: Renderer screen area + empty selection

### DIFF
--- a/src/Application/components/Header/Header.tsx
+++ b/src/Application/components/Header/Header.tsx
@@ -15,16 +15,14 @@ const HeaderLayout = styled.div`
   display: flex;
   align-items: center;
 
-  font-family: monospace;
-  color: #000;
-  font-size: large;
-  font-weight: 900;
-
   background: #fff;
   border: solid 6px #000;
 `;
 
-const Title = styled.div`
+const Title = styled.h2`
   position: absolute;
   left: 50%;
+  font-family: monospace;
+  color: #000;
+  font-weight: 900;
 `;

--- a/src/Application/components/Menu/BurgerIcon.tsx
+++ b/src/Application/components/Menu/BurgerIcon.tsx
@@ -30,9 +30,9 @@ const ExternalBar = styled.div<{ $open: boolean }>`
   height: 6px;
   width: 60px;
   transition-property: opacity;
-  transition-delay: ${({ $open }) => ($open ? "650ms" : 0)};
+  transition-delay: ${({ $open }) => ($open ? 0 : "650ms")};
   transition-duration: ${VANISH_DELAY};
-  opacity: ${({ $open }) => ($open ? "1" : "0")};
+  opacity: ${({ $open }) => ($open ? "0" : "1")};
 `;
 
 const BarTop = styled(ExternalBar)`
@@ -55,5 +55,9 @@ const BarMiddle = styled.div<{ $open: boolean; $order: string }>`
   transition-duration: 500ms;
 
   transform: ${({ $order, $open }) =>
-    $open ? "none" : $order === "positiv" ? "rotate(45deg)" : "rotate(-45deg)"};
+    $open
+      ? $order === "positiv"
+        ? "rotate(45deg)"
+        : "rotate(-45deg)"
+      : "none"};
 `;

--- a/src/Application/components/Menu/BurgerIcon.tsx
+++ b/src/Application/components/Menu/BurgerIcon.tsx
@@ -30,9 +30,9 @@ const ExternalBar = styled.div<{ $open: boolean }>`
   height: 6px;
   width: 60px;
   transition-property: opacity;
-  transition-delay: ${({ $open }) => ($open ? 0 : "650ms")};
+  transition-delay: ${({ $open }) => ($open ? "650ms" : 0)};
   transition-duration: ${VANISH_DELAY};
-  opacity: ${({ $open }) => ($open ? "0" : "1")};
+  opacity: ${({ $open }) => ($open ? "1" : "0")};
 `;
 
 const BarTop = styled(ExternalBar)`
@@ -55,9 +55,5 @@ const BarMiddle = styled.div<{ $open: boolean; $order: string }>`
   transition-duration: 500ms;
 
   transform: ${({ $order, $open }) =>
-    $open
-      ? $order === "positiv"
-        ? "rotate(45deg)"
-        : "rotate(-45deg)"
-      : "none"};
+    $open ? "none" : $order === "positiv" ? "rotate(45deg)" : "rotate(-45deg)"};
 `;

--- a/src/Application/components/Menu/Panel.tsx
+++ b/src/Application/components/Menu/Panel.tsx
@@ -40,18 +40,15 @@ export const Panel = () => {
 };
 
 const MenuPanelLayout = styled.div<{ $isVisible: boolean }>`
-  position: fixed;
-  // Header height - bottom border size
-  top: 66px;
   width: 240px;
-  height: ${({ $isVisible }) => ($isVisible ? "0%" : "calc(100% - 72px)")};
-
+  height: 100%;
+  position: relative;
   background: #fff;
-  transition: height;
-  transition-duration: 450ms;
-
-  overflow: auto;
-
   border-right: solid 6px #000;
   border-bottom: solid 6px #000;
+  overflow: auto;
+
+  margin-left: ${({ $isVisible }) => ($isVisible ? "0" : "-246px")};
+  transition: margin-left;
+  transition-duration: 450ms;
 `;

--- a/src/Application/components/Renderer/EmptyState.tsx
+++ b/src/Application/components/Renderer/EmptyState.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 const EmptyState = () => {
   return (
     <NoComponentWrapper>
-      <h2>No component selected</h2>
+      <h3>No component selected</h3>
     </NoComponentWrapper>
   );
 };
@@ -13,6 +13,10 @@ const NoComponentWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  font-family: monospace;
+  color: #000;
+  font-weight: 900;
 `;
 
 export { EmptyState };

--- a/src/Application/components/Renderer/EmptyState.tsx
+++ b/src/Application/components/Renderer/EmptyState.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+const EmptyState = () => {
+  return (
+    <NoComponentWrapper>
+      <h2>No component selected</h2>
+    </NoComponentWrapper>
+  );
+};
+
+const NoComponentWrapper = styled.div`
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export { EmptyState };

--- a/src/Application/components/Renderer/Renderer.tsx
+++ b/src/Application/components/Renderer/Renderer.tsx
@@ -24,7 +24,7 @@ const Layout = styled.div`
   background-color: white;
   border-radius: 10px;
   margin: 8px;
-  width: 100%;
   padding: 4px;
   border: solid 6px #000;
+  flex: 1;
 `;

--- a/src/Application/components/Renderer/Renderer.tsx
+++ b/src/Application/components/Renderer/Renderer.tsx
@@ -1,12 +1,30 @@
 import { useRecoilValue } from "recoil";
+import styled from "styled-components";
+
 import { componentConfig } from "@store";
+
+import { EmptyState } from "./EmptyState";
 
 export const Renderer = () => {
   const config = useRecoilValue(componentConfig);
 
   if (!config) {
-    return <p>NO COMPONENT SELECTED</p>;
+    return (
+      <Layout>
+        <EmptyState />
+      </Layout>
+    );
   }
   const { component } = config;
-  return component();
+
+  return <Layout>{component()}</Layout>;
 };
+
+const Layout = styled.div`
+  background-color: white;
+  border-radius: 10px;
+  margin: 8px;
+  width: 100%;
+  padding: 4px;
+  border: solid 6px #000;
+`;

--- a/src/Application/components/Renderer/index.ts
+++ b/src/Application/components/Renderer/index.ts
@@ -1,1 +1,1 @@
-export {Renderer} from './Renderer';
+export { Renderer } from './Renderer';

--- a/src/Application/index.tsx
+++ b/src/Application/index.tsx
@@ -4,7 +4,7 @@ import { Layout } from "./components/Layout";
 import { RecoilRoot, useSetRecoilState } from "recoil";
 import { components as componentsConfig } from "../library";
 import { Renderer } from "./components/Renderer";
-import { componentIds } from "@store/index";
+import { componentIds } from "@store";
 function App() {
   const setComponentIds = useSetRecoilState(componentIds);
 


### PR DESCRIPTION
closes #14 .

- [x] Add an UI for the area where the component is rendered.
- [x] Modify the pannel : slide from side of screen, In the same Dom tree level as the render area, to push it when open
- [x] fix: The animation of Burger icon is buggued ( reversed state)